### PR TITLE
Fix code quality issues from simplify and external reviews

### DIFF
--- a/Sources/Markviewz/ContentView.swift
+++ b/Sources/Markviewz/ContentView.swift
@@ -48,6 +48,7 @@ struct ContentView: View {
             .onReceive(appDelegate.$fileToOpen) { url in
                 if let url = url {
                     openFile(url)
+                    appDelegate.fileToOpen = nil
                 }
             }
     }
@@ -64,16 +65,14 @@ struct ContentView: View {
             htmlContent = wrapHTMLPage(body: html)
             baseURL = url.deletingLastPathComponent()
             windowTitle = url.lastPathComponent
-            // Update dock tooltip to show filename instead of "Markviewz"
-            DispatchQueue.main.async {
-                NSApp.windows.first?.miniwindowTitle = url.lastPathComponent
-            }
         } catch {
             htmlContent = wrapHTMLPage(body: "<p style='color:red'>Error reading file: \(error.localizedDescription)</p>")
             windowTitle = "Markviewz"
-            DispatchQueue.main.async {
-                NSApp.windows.first?.miniwindowTitle = "Markviewz"
-            }
+        }
+
+        // Sync dock tooltip with window title
+        DispatchQueue.main.async {
+            NSApp.windows.first?.miniwindowTitle = windowTitle
         }
     }
 }

--- a/Sources/Markviewz/MarkdownRenderer.swift
+++ b/Sources/Markviewz/MarkdownRenderer.swift
@@ -60,12 +60,6 @@ func renderMarkdown(_ markdown: String) -> String {
 
 /// Extract YAML frontmatter (between --- delimiters at start of file)
 private func extractFrontmatter(_ markdown: String) -> (frontmatter: String?, body: String) {
-    let trimmed = markdown.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard trimmed.hasPrefix("---") else {
-        return (nil, markdown)
-    }
-
-    // Find closing ---
     let lines = markdown.components(separatedBy: "\n")
     guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else {
         return (nil, markdown)

--- a/Sources/Markviewz/MarkdownWebView.swift
+++ b/Sources/Markviewz/MarkdownWebView.swift
@@ -11,6 +11,10 @@ struct MarkdownWebView: NSViewRepresentable {
     let html: String
     var baseURL: URL?
 
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
         config.preferences.setValue(true, forKey: "developerExtrasEnabled")
@@ -22,8 +26,12 @@ struct MarkdownWebView: NSViewRepresentable {
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
+        let loadKey = html + (baseURL?.absoluteString ?? "")
+        guard loadKey != context.coordinator.lastLoadKey else { return }
+        context.coordinator.lastLoadKey = loadKey
+
         if let baseURL = baseURL {
-            // Write HTML to a temp file alongside the markdown so WKWebView
+            // Write HTML to a dotfile alongside the markdown so WKWebView
             // can access local images via relative paths.
             let tempFile = baseURL.appendingPathComponent(".markviewz-preview.html")
             do {
@@ -35,5 +43,9 @@ struct MarkdownWebView: NSViewRepresentable {
         } else {
             webView.loadHTMLString(html, baseURL: nil)
         }
+    }
+
+    class Coordinator {
+        var lastLoadKey: String?
     }
 }

--- a/Sources/Markviewz/MarkviewzApp.swift
+++ b/Sources/Markviewz/MarkviewzApp.swift
@@ -23,7 +23,7 @@ struct MarkviewzApp: App {
 
     private func printDocument() {
         guard let webView = WebViewStore.shared.webView else { return }
-        let printInfo = NSPrintInfo.shared
+        let printInfo = NSPrintInfo.shared.copy() as! NSPrintInfo
         printInfo.horizontalPagination = .fit
         printInfo.verticalPagination = .automatic
         printInfo.isHorizontallyCentered = true
@@ -51,10 +51,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         let args = CommandLine.arguments
         if args.count > 1 {
             let path = (args[1] as NSString).standardizingPath
-            let url = URL(fileURLWithPath: path)
-            if FileManager.default.fileExists(atPath: url.path) {
-                fileToOpen = url
-            }
+            fileToOpen = URL(fileURLWithPath: path)
         }
     }
 


### PR DESCRIPTION
## Summary

- Dedup `updateNSView` with Coordinator to skip redundant disk writes and reloads
- Include `baseURL` in cache key to prevent stale renders across directories
- Remove TOCTOU `fileExists` check; `openFile` handles errors
- Remove redundant `trimmed` prefix guard in `extractFrontmatter`
- Copy `NSPrintInfo.shared` before mutating
- Consolidate `miniwindowTitle` assignment after do/catch
- Reset `fileToOpen` to nil after consumption

Closes #1

## Test plan

- [x] `swift build` passes
- [x] `/simplify` review — no further improvements
- [x] Gemini CLI review — LGTM
- [x] Codex CLI review — LGTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)