### PR TITLE
Add Claude Code plugin for /markviewz skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "Markviewz",
+  "owner": {
+    "name": "Dave Remy"
+  },
+  "plugins": [
+    {
+      "name": "markviewz",
+      "source": "./plugins/markviewz",
+      "description": "Open .md files in a native macOS markdown viewer from Claude Code",
+      "version": "1.0.0",
+      "author": {
+        "name": "Dave Remy"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ That's it. No editing, no bloat, no Electron. Just a native Mac app that renders
 
 ## Install
 
+### Claude Code Plugin (recommended)
+
+If you use [Claude Code](https://claude.com/claude-code), install Markviewz as a plugin to get the `/markviewz` skill:
+
+```
+/plugin marketplace add daveremy/Markviewz
+/plugin install markviewz@Markviewz
+```
+
+Then ask Claude to "show me the README" or use `/markviewz README.md`. If the binary isn't installed yet, Claude will guide you through the install.
+
+### Manual Install
+
 Requires macOS 14+ and Swift 5.9+.
 
 ```bash
@@ -42,7 +55,10 @@ This builds a release binary, creates `Markviewz.app` in `/Applications`, and in
 ## Usage
 
 ```bash
-# Open from the terminal (reuses running instance)
+# From Claude Code
+/markviewz README.md
+
+# From the terminal (reuses running instance)
 markviewz notes.md
 
 # Or use macOS open command

--- a/plugins/markviewz/.claude-plugin/plugin.json
+++ b/plugins/markviewz/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "markviewz",
+  "description": "Open .md files in a native macOS markdown viewer. Adds the /markviewz skill to preview markdown files with proper formatting, dark mode, and GitHub-style typography.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Dave Remy"
+  },
+  "homepage": "https://github.com/daveremy/Markviewz",
+  "repository": "https://github.com/daveremy/Markviewz",
+  "license": "MIT"
+}

--- a/plugins/markviewz/scripts/install-binary.sh
+++ b/plugins/markviewz/scripts/install-binary.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Install Markviewz binary and CLI wrapper.
+# Clones the latest source and builds from scratch.
+set -e
+
+REPO_URL="https://github.com/daveremy/Markviewz.git"
+BUILD_DIR="/tmp/Markviewz"
+
+echo "Downloading Markviewz..."
+rm -rf "$BUILD_DIR"
+git clone --depth 1 "$REPO_URL" "$BUILD_DIR"
+
+cd "$BUILD_DIR"
+exec ./install.sh

--- a/plugins/markviewz/skills/markviewz/SKILL.md
+++ b/plugins/markviewz/skills/markviewz/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: markviewz
+description: Open and view markdown files with Markviewz. Use when the user asks to view, show, preview, or open a .md or markdown file.
+---
+
+Open a markdown file in Markviewz for viewing.
+
+Run: `markviewz $ARGUMENTS`
+
+If the command fails because markviewz is not installed, tell the user to install it:
+
+```bash
+rm -rf /tmp/Markviewz && git clone --depth 1 https://github.com/daveremy/Markviewz.git /tmp/Markviewz && cd /tmp/Markviewz && ./install.sh
+```
+
+If no file was specified, ask the user which markdown file they want to view.


### PR DESCRIPTION
## Summary

- Add Claude Code plugin/marketplace so users can install the `/markviewz` skill with two commands
- Add install script that clones and builds the binary
- Update README with plugin install instructions

Closes #3

## Test plan

- [x] `swift build` passes
- [x] Plugin JSON manifests are valid
- [x] install-binary.sh clones and delegates to install.sh
- [x] SKILL.md install fallback is idempotent (rm -rf, cd, ./install.sh)
- [x] Gemini CLI review — LGTM
- [x] Codex CLI review — LGTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)