### PR TITLE
Add Gemini CLI extension for /markviewz skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ If you use [Claude Code](https://claude.com/claude-code), install Markviewz as a
 
 Then ask Claude to "show me the README" or use `/markviewz README.md`. If the binary isn't installed yet, Claude will guide you through the install.
 
+### Gemini CLI Extension
+
+If you use [Gemini CLI](https://github.com/google-gemini/gemini-cli), install the extension:
+
+```
+gemini extensions install https://github.com/daveremy/Markviewz.git
+```
+
 ### Manual Install
 
 Requires macOS 14+ and Swift 5.9+.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,4 @@
+{
+  "name": "markviewz",
+  "version": "1.0.0"
+}

--- a/skills/markviewz/SKILL.md
+++ b/skills/markviewz/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: markviewz
+description: Open and view markdown files with Markviewz, a native macOS markdown viewer. Use when the user asks to view, show, preview, or open a .md or markdown file.
+---
+
+Open a markdown file in Markviewz for viewing.
+
+Run: `markviewz $ARGUMENTS`
+
+If the command fails because markviewz is not installed, tell the user to install it:
+
+```bash
+rm -rf /tmp/Markviewz && git clone --depth 1 https://github.com/daveremy/Markviewz.git /tmp/Markviewz && cd /tmp/Markviewz && ./install.sh
+```
+
+If no file was specified, ask the user which markdown file they want to view.


### PR DESCRIPTION
## Summary

- Add `gemini-extension.json` manifest at repo root
- Add `skills/markviewz/SKILL.md` for Gemini's skill discovery
- Update README with Gemini CLI install instructions

Users install with:
```
gemini extensions install https://github.com/daveremy/Markviewz.git
```

Closes #5

## Test plan

- [x] `gemini extensions validate` passes
- [x] `gemini extensions link` installs and discovers the skill
- [x] `gemini skills list --all` shows markviewz as enabled
- [x] `gemini extensions uninstall` cleans up correctly
- [x] Codex review — raised false positive about GEMINI.md requirement (verified: skills/ directory works independently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)