### PR TITLE
Add Codex CLI skill for markviewz

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ If you use [Gemini CLI](https://github.com/google-gemini/gemini-cli), install th
 gemini extensions install https://github.com/daveremy/Markviewz.git
 ```
 
+### Codex CLI Skill
+
+If you use [Codex CLI](https://github.com/openai/codex), ask Codex to install the skill:
+
+```
+install the markviewz skill from daveremy/Markviewz at path codex/markviewz
+```
+
 ### Manual Install
 
 Requires macOS 14+ and Swift 5.9+.

--- a/codex/markviewz/SKILL.md
+++ b/codex/markviewz/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: markviewz
+description: Open and view markdown files with Markviewz, a native macOS markdown viewer. Use when the user asks to view, show, preview, or open a .md or markdown file.
+---
+
+Open a markdown file in Markviewz for viewing.
+
+Run: `markviewz $ARGUMENTS`
+
+If the command fails because markviewz is not installed, tell the user to install it:
+
+```bash
+rm -rf /tmp/Markviewz && git clone --depth 1 https://github.com/daveremy/Markviewz.git /tmp/Markviewz && cd /tmp/Markviewz && ./install.sh
+```
+
+If no file was specified, ask the user which markdown file they want to view.


### PR DESCRIPTION
## Summary

- Add `codex/markviewz/SKILL.md` for Codex's skill-installer
- Update README with Codex install instructions

Users install by asking Codex:
```
install the markviewz skill from daveremy/Markviewz at path codex/markviewz
```

Closes #7

## Test plan

- [x] SKILL.md follows Codex skill format (YAML frontmatter + markdown body)
- [x] Path structure matches Codex skill-installer expectations
- [x] Codex CLI review — LGTM
- [x] Gemini CLI review — pending (Codex confirmed format is valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)