### PR TITLE
Add CLI --version and update commands

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
     <key>CFBundleDisplayName</key>
     <string>Markviewz</string>
     <key>CFBundleVersion</key>
-    <string>0.1.0</string>
+    <string>1.0.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>1.0.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+VERSION="1.0.0"
+
 echo "Building Markviewz..."
 swift build -c release 2>&1
 
@@ -17,22 +19,52 @@ cp Info.plist "$CONTENTS/Info.plist"
 
 # Create CLI wrapper script (uses `open -a` to reuse running instance)
 echo "Installing CLI tool..."
-CLI_SCRIPT='#!/bin/bash
+
+write_cli_script() {
+    cat << 'WRAPPER_EOF'
+#!/bin/bash
+MARKVIEWZ_VERSION="__VERSION__"
+
+if [ $# -eq 1 ]; then
+    case "$1" in
+        --version|-v)
+            echo "markviewz $MARKVIEWZ_VERSION"
+            exit 0
+            ;;
+        --help|-h)
+            echo "Usage: markviewz [file.md]"
+            echo "       markviewz --version"
+            echo "       markviewz update"
+            exit 0
+            ;;
+        update)
+            echo "Updating Markviewz..."
+            rm -rf /tmp/Markviewz
+            git clone --depth 1 https://github.com/daveremy/Markviewz.git /tmp/Markviewz && \
+                cd /tmp/Markviewz && exec ./install.sh
+            echo "Error: Failed to clone repository." >&2
+            exit 1
+            ;;
+    esac
+fi
+
 if [ $# -eq 0 ]; then
     open -a Markviewz
 else
     open -a Markviewz "$@"
-fi'
+fi
+WRAPPER_EOF
+}
 
 if [ -w /usr/local/bin ]; then
     rm -f /usr/local/bin/markviewz
-    echo "$CLI_SCRIPT" > /usr/local/bin/markviewz
+    write_cli_script | sed "s/__VERSION__/$VERSION/" > /usr/local/bin/markviewz
     chmod +x /usr/local/bin/markviewz
     CLI_PATH="/usr/local/bin/markviewz"
 else
     mkdir -p "$HOME/.local/bin"
     rm -f "$HOME/.local/bin/markviewz"
-    echo "$CLI_SCRIPT" > "$HOME/.local/bin/markviewz"
+    write_cli_script | sed "s/__VERSION__/$VERSION/" > "$HOME/.local/bin/markviewz"
     chmod +x "$HOME/.local/bin/markviewz"
     CLI_PATH="$HOME/.local/bin/markviewz"
     echo "  (Add ~/.local/bin to your PATH if not already there)"


### PR DESCRIPTION
## Summary
- Add `--version`/`-v` flag to show installed version
- Add `--help`/`-h` flag for usage info
- Add `update` subcommand that clones latest and re-runs install
- Rewrite CLI wrapper generation using heredoc + sed for clean escaping
- Sync Info.plist version to 1.0.0

Closes #11

## Test plan
- [ ] Run `./install.sh` and verify CLI installs
- [ ] Run `markviewz --version` → shows "markviewz 1.0.0"
- [ ] Run `markviewz --help` → shows usage
- [ ] Run `markviewz update` → clones and reinstalls
- [ ] Run `markviewz file.md` → still opens files normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)