### PR TITLE
Fix print outputting blank pages (#18)

### DIFF
--- a/Sources/Markviewz/MarkviewzApp.swift
+++ b/Sources/Markviewz/MarkviewzApp.swift
@@ -22,7 +22,12 @@ struct MarkviewzApp: App {
     }
 
     private func printDocument() {
-        guard let webView = WebViewStore.shared.webView else { return }
+        guard let webView = WebViewStore.shared.webView,
+              let window = webView.window else { return }
+
+        webView.setValue(true, forKey: "drawsBackground")
+        webView.display()
+
         let printInfo = NSPrintInfo.shared.copy() as! NSPrintInfo
         printInfo.horizontalPagination = .fit
         printInfo.verticalPagination = .automatic
@@ -36,7 +41,9 @@ struct MarkviewzApp: App {
         let printOp = webView.printOperation(with: printInfo)
         printOp.showsPrintPanel = true
         printOp.showsProgressPanel = true
-        printOp.run()
+        printOp.runModal(for: window, delegate: nil, didRun: nil, contextInfo: nil)
+
+        webView.setValue(false, forKey: "drawsBackground")
     }
 }
 

--- a/Sources/Markviewz/Styles.swift
+++ b/Sources/Markviewz/Styles.swift
@@ -175,6 +175,43 @@ details.frontmatter + hr {
     .string { color: #a5d6ff; }
     .comment { color: #8b949e; }
 }
+
+@media print {
+    body {
+        color: #24292f !important;
+        background-color: #ffffff !important;
+        max-width: 100%;
+        padding: 0;
+        margin: 0;
+    }
+    a { color: #0969da !important; }
+    code {
+        background-color: rgba(175,184,193,0.2) !important;
+    }
+    pre {
+        background-color: #f6f8fa !important;
+        border-color: #d1d9e0 !important;
+    }
+    blockquote {
+        border-left-color: #d1d9e0 !important;
+        color: #59636e !important;
+    }
+    table th, table td {
+        border-color: #d1d9e0 !important;
+    }
+    table tr:nth-child(2n) {
+        background-color: #f6f8fa !important;
+    }
+    hr {
+        background-color: #d1d9e0 !important;
+    }
+    h1, h2 {
+        border-bottom-color: #d1d9e0 !important;
+    }
+    .keyword { color: #cf222e !important; }
+    .string { color: #0a3069 !important; }
+    .comment { color: #6e7781 !important; }
+}
 """
 
 func wrapHTMLPage(body: String) -> String {


### PR DESCRIPTION
## Summary
- Toggle `drawsBackground = true` and force `display()` before printing so WKWebView's print compositor renders content
- Use `runModal(for:...)` instead of `run()` to allow WKWebView's async print rendering to complete
- Add `@media print` CSS to force light-mode colors on paper regardless of system dark mode

## Test plan
- [ ] Open a markdown file with Markviewz
- [ ] Cmd+P → print preview shows content (not blank)
- [ ] Save as PDF → PDF has content
- [ ] Test in both light and dark mode — print output should always use light-mode colors

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)