### PR TITLE
feat: per-file window reuse (Option D hybrid)

### DIFF
--- a/Sources/Markviewz/ContentView.swift
+++ b/Sources/Markviewz/ContentView.swift
@@ -2,101 +2,100 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 /// Immutable snapshot of what's currently rendered. A single state field
-/// holding the document avoids multiple SwiftUI rebuilds when opening a
+/// holding the document avoids multiple SwiftUI rebuilds when loading a
 /// new file (previously each of html / baseURL / windowTitle was its
 /// own @State, causing the WebView to reload 2–3 times per open).
 struct MarkdownDocument {
     let html: String
     let baseURL: URL?
     let title: String
-
-    static let welcome = MarkdownDocument(
-        html: wrapHTMLPage(body: welcomeHTML),
-        baseURL: nil,
-        title: "Markviewz"
-    )
 }
 
 struct ContentView: View {
-    @EnvironmentObject var appDelegate: AppDelegate
+    /// URL passed in at window creation. Each window binds to one file.
+    let documentURL: URL
 
-    @State private var document: MarkdownDocument = .welcome
-    @State private var showFileImporter = false
+    @State private var document: MarkdownDocument
+
+    init(documentURL: URL) {
+        self.documentURL = documentURL
+        // Preload synchronously so first render isn't empty.
+        _document = State(initialValue: Self.load(from: documentURL))
+    }
 
     var body: some View {
         MarkdownWebView(html: document.html, baseURL: document.baseURL)
             .frame(minWidth: 600, minHeight: 400)
-            .onDrop(of: [.fileURL], isTargeted: nil) { providers in
-                guard let provider = providers.first else { return false }
-                _ = provider.loadObject(ofClass: URL.self) { url, _ in
-                    if let url = url {
-                        DispatchQueue.main.async {
-                            openFile(url)
-                        }
-                    }
-                }
-                return true
-            }
-            .fileImporter(
-                isPresented: $showFileImporter,
-                allowedContentTypes: [
-                    UTType(filenameExtension: "md") ?? .plainText,
-                    UTType(filenameExtension: "markdown") ?? .plainText,
-                    .plainText,
-                ],
-                allowsMultipleSelection: false
-            ) { result in
-                if case .success(let urls) = result, let url = urls.first {
-                    openFile(url)
-                }
-            }
-            .toolbar {
-                ToolbarItem(placement: .automatic) {
-                    Button("Open...") {
-                        showFileImporter = true
-                    }
-                    .keyboardShortcut("o", modifiers: .command)
-                }
-            }
             .navigationTitle(document.title)
-            .onReceive(appDelegate.$fileToOpen.compactMap { $0 }) { url in
-                openFile(url)
-                // Reset AFTER consuming. compactMap above filters the nil
-                // we set here, so onReceive doesn't fire again.
-                appDelegate.fileToOpen = nil
+            .onAppear {
+                DispatchQueue.main.async {
+                    NSApp.keyWindow?.miniwindowTitle = documentURL.lastPathComponent
+                }
             }
     }
 
-    private func openFile(_ url: URL) {
+    private static func load(from url: URL) -> MarkdownDocument {
         let accessing = url.startAccessingSecurityScopedResource()
         defer {
             if accessing { url.stopAccessingSecurityScopedResource() }
         }
-
-        let newDocument: MarkdownDocument
         do {
             let markdown = try String(contentsOf: url, encoding: .utf8)
             let html = renderMarkdown(markdown)
-            newDocument = MarkdownDocument(
+            return MarkdownDocument(
                 html: wrapHTMLPage(body: html),
                 baseURL: url.deletingLastPathComponent(),
                 title: shortenedPath(url.path)
             )
         } catch {
-            newDocument = MarkdownDocument(
+            return MarkdownDocument(
                 html: wrapHTMLPage(body: "<p style='color:red'>Error reading file: \(error.localizedDescription)</p>"),
                 baseURL: nil,
                 title: "Markviewz"
             )
         }
+    }
+}
 
-        // Single atomic state write — SwiftUI rebuilds the view once,
-        // MarkdownWebView.updateNSView loads the content once.
-        document = newDocument
+/// Shown when the app is launched without a file argument.
+struct WelcomeView: View {
+    let onOpen: (URL) -> Void
 
-        // Dock tooltip shows just the filename
-        DispatchQueue.main.async {
-            NSApp.windows.first?.miniwindowTitle = url.lastPathComponent
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Markviewz")
+                .font(.system(size: 48, weight: .light))
+            Text("Open a Markdown file to get started")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Button("Open…") {
+                let panel = NSOpenPanel()
+                panel.allowedContentTypes = [
+                    UTType(filenameExtension: "md") ?? .plainText,
+                    UTType(filenameExtension: "markdown") ?? .plainText,
+                    .plainText,
+                ]
+                panel.allowsMultipleSelection = false
+                if panel.runModal() == .OK, let url = panel.url {
+                    onOpen(url)
+                }
+            }
+            .keyboardShortcut("o", modifiers: .command)
+            Text("or drag a .md file here")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            guard let provider = providers.first else { return false }
+            _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                if let url = url {
+                    DispatchQueue.main.async {
+                        onOpen(url)
+                    }
+                }
+            }
+            return true
         }
     }
 }
@@ -114,7 +113,6 @@ private func shortenedPath(_ path: String) -> String {
     let maxLength = 60
     guard display.count > maxLength else { return display }
 
-    // Keep first component and last two path components, join with ellipsis
     let components = display.components(separatedBy: "/").filter { !$0.isEmpty }
     guard components.count > 3 else { return display }
 
@@ -122,11 +120,3 @@ private func shortenedPath(_ path: String) -> String {
     let suffix = components.suffix(2).joined(separator: "/")
     return prefix + "/\u{2026}/" + suffix
 }
-
-private let welcomeHTML = """
-<div style="text-align: center; margin-top: 100px; opacity: 0.5;">
-    <h1>Markviewz</h1>
-    <p>Open a Markdown file to get started</p>
-    <p style="font-size: 14px;">File → Open (⌘O) or drag a .md file here</p>
-</div>
-"""

--- a/Sources/Markviewz/MarkviewzApp.swift
+++ b/Sources/Markviewz/MarkviewzApp.swift
@@ -6,16 +6,22 @@ struct MarkviewzApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     var body: some Scene {
-        // Single-window viewer. `Window` (not `WindowGroup`) ensures one
-        // window is reused across file-open events instead of spawning
-        // a new window per invocation of `markviewz <file>`.
-        Window("Markviewz", id: "main") {
-            ContentView()
-                .environmentObject(appDelegate)
+        // Hidden Settings scene — present only to host menu bar commands.
+        // All real windows are managed by AppDelegate via AppKit so we can
+        // implement "reuse window if already showing this file, otherwise
+        // spawn a new one" (SwiftUI's Scene system doesn't compose well
+        // with that dedup-by-value + create-new-for-fresh-value pattern).
+        Settings {
+            EmptyView()
         }
         .commands {
             CommandGroup(replacing: .newItem) { }
             CommandGroup(after: .newItem) {
+                Button("Open…") {
+                    NSApp.sendAction(#selector(AppDelegate.openFileDialog(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("o", modifiers: .command)
+
                 Button("Print…") {
                     printDocument()
                 }
@@ -51,29 +57,145 @@ struct MarkviewzApp: App {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
-    @Published var fileToOpen: URL?
+    /// Windows keyed by canonical file URL. One window per unique file.
+    /// Opening a file that's already visible just brings its window forward.
+    private var windowsByURL: [URL: NSWindow] = [:]
+
+    /// Welcome/no-file window, shown when app launches with no arguments
+    /// and there's no other window visible.
+    private var welcomeWindow: NSWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
 
-        // Handle CLI arguments (when running binary directly)
+        // Close the default Settings window Apple opens automatically.
+        // We don't use it; we manage windows ourselves.
+        DispatchQueue.main.async {
+            NSApp.windows
+                .filter { $0.className.contains("SettingsWindow") || $0.title == "Markviewz Settings" }
+                .forEach { $0.close() }
+        }
+
+        // CLI invocation: `markviewz` binary directly with file arg.
+        // (When invoked via `open -a Markviewz file.md`, file URLs arrive
+        // through application(_:open:) instead.)
         let args = CommandLine.arguments
         if args.count > 1 {
             let path = (args[1] as NSString).standardizingPath
-            fileToOpen = URL(fileURLWithPath: path)
+            openFile(URL(fileURLWithPath: path))
+        } else {
+            // No file given and nothing else is opening — show welcome.
+            DispatchQueue.main.async { [weak self] in
+                if let self = self, self.windowsByURL.isEmpty {
+                    self.showWelcome()
+                }
+            }
         }
     }
 
-    // Handle files opened via `open -a Markviewz file.md` or Finder double-click
+    /// Called by macOS when the app receives file URLs via
+    /// `open -a Markviewz file.md` or Finder double-click.
     func application(_ application: NSApplication, open urls: [URL]) {
-        if let url = urls.first {
-            fileToOpen = url
-        }
-        // Bring window to front when opening a new file
+        urls.forEach { openFile($0) }
         NSApp.activate(ignoringOtherApps: true)
-        if let window = NSApp.windows.first {
-            window.makeKeyAndOrderFront(nil)
+    }
+
+    /// Re-open behavior: when user clicks the dock icon with no windows,
+    /// show welcome rather than doing nothing.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag && windowsByURL.isEmpty {
+            showWelcome()
         }
+        return true
+    }
+
+    /// Don't quit when the last window closes — user may re-open via Dock.
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+
+    // MARK: - File opening
+
+    fileprivate func openFile(_ url: URL) {
+        let canonical = canonicalize(url)
+
+        // Already open — bring forward.
+        if let existing = windowsByURL[canonical] {
+            existing.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        // Not open — spawn a new window.
+        let host = NSHostingController(rootView: ContentView(documentURL: canonical))
+        let window = NSWindow(contentViewController: host)
+        window.title = canonical.lastPathComponent
+        window.setContentSize(NSSize(width: 900, height: 720))
+        window.styleMask.insert(.resizable)
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+
+        windowsByURL[canonical] = window
+
+        // Clean up registry when the user closes the window.
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.windowsByURL.removeValue(forKey: canonical)
+        }
+
+        // Close the welcome window once a real doc is open.
+        welcomeWindow?.close()
+        welcomeWindow = nil
+    }
+
+    // MARK: - Welcome window
+
+    private func showWelcome() {
+        if let existing = welcomeWindow {
+            existing.makeKeyAndOrderFront(nil)
+            return
+        }
+        let host = NSHostingController(rootView: WelcomeView(onOpen: { [weak self] url in
+            self?.openFile(url)
+        }))
+        let window = NSWindow(contentViewController: host)
+        window.title = "Markviewz"
+        window.setContentSize(NSSize(width: 600, height: 400))
+        window.styleMask.insert(.resizable)
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        welcomeWindow = window
+
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.welcomeWindow = nil
+        }
+    }
+
+    // MARK: - Menu command
+
+    @objc func openFileDialog(_ sender: Any?) {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.init(filenameExtension: "md") ?? .plainText,
+                                     .init(filenameExtension: "markdown") ?? .plainText,
+                                     .plainText]
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            openFile(url)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Canonicalize a URL so the same file under different paths (symlinks,
+    /// relative paths, tilde-expansion) resolves to the same registry key.
+    private func canonicalize(_ url: URL) -> URL {
+        url.resolvingSymlinksInPath().standardizedFileURL
     }
 }


### PR DESCRIPTION
## Summary

Markviewz now opens a separate window per unique file, and re-opens of a file that's already displayed bring its existing window to front instead of spawning a duplicate.

This replaces the previous behavior (all files replaced the single window's content), which was too aggressive for research/comparison workflows.

## Behavior matrix

| Action | Before | After |
|---|---|---|
| \`markviewz A; markviewz B; markviewz C\` | One window showing only C | Three windows (A, B, C) |
| \`markviewz A\` while A is already open | Window re-rendered A | Existing A window brought forward, no new window |
| \`markviewz\` (no args) | Single window (empty content) | Single-instance welcome window |
| Click dock with no windows | Nothing | Welcome re-opens |
| Close last window | App quits | App stays running; dock-click reopens welcome |

## Implementation

Moved window management from SwiftUI Scene to AppKit.

\`AppDelegate\` maintains:

\`\`\`swift
private var windowsByURL: [URL: NSWindow] = [:]
private var welcomeWindow: NSWindow?
\`\`\`

\`application(_:open:)\` dispatches to \`openFile(url)\`:
1. Canonicalize URL (resolve symlinks, standardize)
2. If already in \`windowsByURL\` → \`makeKeyAndOrderFront\`
3. Else → create \`NSHostingController(ContentView(documentURL:))\` + \`NSWindow\`, register in dict
4. Track \`willCloseNotification\` to remove from dict on close

\`ContentView\` now takes \`documentURL\` as a constructor parameter and loads content synchronously in \`init\` via \`State(initialValue:)\`. No more AppDelegate publisher subscription; each window binds to one file at creation.

\`WelcomeView\` extracted as a separate SwiftUI view for the no-file state. Single-instance (only one welcome ever exists).

SwiftUI Scene reduced to \`Settings { EmptyView() }\` purely to host menu bar commands (Open, Print). The auto-opened Settings window is closed in \`applicationDidFinishLaunching\`.

## Test plan

- [x] \`swift build\` passes
- [x] \`./install.sh\` installs cleanly
- [x] Open 3 unique files → 3 windows
- [x] Re-open one of them → still 3 windows (existing brought forward)
- [x] Open with no args → single welcome window
- [x] Re-click dock with no windows → welcome re-opens

## Impact

This is the final state of the Markviewz UX for reading workflows. Paired with the atomic-state fix (PR #20), opening a file now:
1. Finds or creates a window (no spurious spawning)
2. Brings it forward
3. One SwiftUI rebuild → one WebView load

Closes the "same doc opened 3 times" bug Dave reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)