### PR TITLE
fix: auto-reload when file changes on disk (#23)

### DIFF
--- a/Sources/Markviewz/ContentView.swift
+++ b/Sources/Markviewz/ContentView.swift
@@ -1,16 +1,30 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+/// Immutable snapshot of what's currently rendered. A single state field
+/// holding the document avoids multiple SwiftUI rebuilds when opening a
+/// new file (previously each of html / baseURL / windowTitle was its
+/// own @State, causing the WebView to reload 2–3 times per open).
+struct MarkdownDocument {
+    let html: String
+    let baseURL: URL?
+    let title: String
+
+    static let welcome = MarkdownDocument(
+        html: wrapHTMLPage(body: welcomeHTML),
+        baseURL: nil,
+        title: "Markviewz"
+    )
+}
+
 struct ContentView: View {
     @EnvironmentObject var appDelegate: AppDelegate
 
-    @State private var htmlContent: String = wrapHTMLPage(body: welcomeHTML)
-    @State private var baseURL: URL?
+    @State private var document: MarkdownDocument = .welcome
     @State private var showFileImporter = false
-    @State private var windowTitle = "Markviewz"
 
     var body: some View {
-        MarkdownWebView(html: htmlContent, baseURL: baseURL)
+        MarkdownWebView(html: document.html, baseURL: document.baseURL)
             .frame(minWidth: 600, minHeight: 400)
             .onDrop(of: [.fileURL], isTargeted: nil) { providers in
                 guard let provider = providers.first else { return false }
@@ -44,12 +58,12 @@ struct ContentView: View {
                     .keyboardShortcut("o", modifiers: .command)
                 }
             }
-            .navigationTitle(windowTitle)
-            .onReceive(appDelegate.$fileToOpen) { url in
-                if let url = url {
-                    openFile(url)
-                    appDelegate.fileToOpen = nil
-                }
+            .navigationTitle(document.title)
+            .onReceive(appDelegate.$fileToOpen.compactMap { $0 }) { url in
+                openFile(url)
+                // Reset AFTER consuming. compactMap above filters the nil
+                // we set here, so onReceive doesn't fire again.
+                appDelegate.fileToOpen = nil
             }
     }
 
@@ -59,16 +73,26 @@ struct ContentView: View {
             if accessing { url.stopAccessingSecurityScopedResource() }
         }
 
+        let newDocument: MarkdownDocument
         do {
             let markdown = try String(contentsOf: url, encoding: .utf8)
             let html = renderMarkdown(markdown)
-            htmlContent = wrapHTMLPage(body: html)
-            baseURL = url.deletingLastPathComponent()
-            windowTitle = shortenedPath(url.path)
+            newDocument = MarkdownDocument(
+                html: wrapHTMLPage(body: html),
+                baseURL: url.deletingLastPathComponent(),
+                title: shortenedPath(url.path)
+            )
         } catch {
-            htmlContent = wrapHTMLPage(body: "<p style='color:red'>Error reading file: \(error.localizedDescription)</p>")
-            windowTitle = "Markviewz"
+            newDocument = MarkdownDocument(
+                html: wrapHTMLPage(body: "<p style='color:red'>Error reading file: \(error.localizedDescription)</p>"),
+                baseURL: nil,
+                title: "Markviewz"
+            )
         }
+
+        // Single atomic state write — SwiftUI rebuilds the view once,
+        // MarkdownWebView.updateNSView loads the content once.
+        document = newDocument
 
         // Dock tooltip shows just the filename
         DispatchQueue.main.async {

--- a/Sources/Markviewz/ContentView.swift
+++ b/Sources/Markviewz/ContentView.swift
@@ -39,9 +39,11 @@ final class FileWatcher: ObservableObject {
         fileDescriptor = -1
     }
 
-    private func startWatching() {
+    /// Open the file and attach a dispatch source. Returns true on success.
+    @discardableResult
+    private func startWatching() -> Bool {
         let fd = open(url.path, O_EVTONLY)
-        guard fd >= 0 else { return }
+        guard fd >= 0 else { return false }
         fileDescriptor = fd
 
         let src = DispatchSource.makeFileSystemObjectSource(
@@ -64,6 +66,7 @@ final class FileWatcher: ObservableObject {
         src.setCancelHandler { close(fd) }
         self.source = src
         src.resume()
+        return true
     }
 
     /// Re-establish the watch after an atomic save (delete + rename).
@@ -80,37 +83,14 @@ final class FileWatcher: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self = self else { return }
 
-            let fd = open(self.url.path, O_EVTONLY)
-            if fd < 0 {
-                if attempt < maxAttempts - 1 {
-                    self.restartWatching(attempt: attempt + 1)
-                }
-                // After all retries, stop watching. Content stays as-is.
-                return
-            }
-
-            self.fileDescriptor = fd
-            let src = DispatchSource.makeFileSystemObjectSource(
-                fileDescriptor: fd,
-                eventMask: [.write, .delete, .rename, .revoke],
-                queue: .main
-            )
-            src.setEventHandler { [weak self] in
-                guard let self = self else { return }
-                let flags = src.data
-                if flags.contains(.delete) || flags.contains(.rename) || flags.contains(.revoke) {
-                    self.restartWatching()
-                    return
-                }
+            if self.startWatching() {
+                // Signal change AFTER successfully re-establishing the watch,
+                // so the view reloads the new file content.
                 self.changeCount += 1
+            } else if attempt < maxAttempts - 1 {
+                self.restartWatching(attempt: attempt + 1)
             }
-            src.setCancelHandler { close(fd) }
-            self.source = src
-            src.resume()
-
-            // Signal change AFTER successfully re-establishing the watch,
-            // so the view reloads the new file content.
-            self.changeCount += 1
+            // After all retries, stop watching. Content stays as-is.
         }
     }
 }

--- a/Sources/Markviewz/ContentView.swift
+++ b/Sources/Markviewz/ContentView.swift
@@ -2,101 +2,100 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 /// Immutable snapshot of what's currently rendered. A single state field
-/// holding the document avoids multiple SwiftUI rebuilds when opening a
+/// holding the document avoids multiple SwiftUI rebuilds when loading a
 /// new file (previously each of html / baseURL / windowTitle was its
 /// own @State, causing the WebView to reload 2–3 times per open).
 struct MarkdownDocument {
     let html: String
     let baseURL: URL?
     let title: String
-
-    static let welcome = MarkdownDocument(
-        html: wrapHTMLPage(body: welcomeHTML),
-        baseURL: nil,
-        title: "Markviewz"
-    )
 }
 
 struct ContentView: View {
-    @EnvironmentObject var appDelegate: AppDelegate
+    /// URL passed in at window creation. Each window binds to one file.
+    let documentURL: URL
 
-    @State private var document: MarkdownDocument = .welcome
-    @State private var showFileImporter = false
+    @State private var document: MarkdownDocument
+
+    init(documentURL: URL) {
+        self.documentURL = documentURL
+        // Preload synchronously so first render isn't empty.
+        _document = State(initialValue: Self.load(from: documentURL))
+    }
 
     var body: some View {
         MarkdownWebView(html: document.html, baseURL: document.baseURL)
             .frame(minWidth: 600, minHeight: 400)
-            .onDrop(of: [.fileURL], isTargeted: nil) { providers in
-                guard let provider = providers.first else { return false }
-                _ = provider.loadObject(ofClass: URL.self) { url, _ in
-                    if let url = url {
-                        DispatchQueue.main.async {
-                            openFile(url)
-                        }
-                    }
-                }
-                return true
-            }
-            .fileImporter(
-                isPresented: $showFileImporter,
-                allowedContentTypes: [
-                    UTType(filenameExtension: "md") ?? .plainText,
-                    UTType(filenameExtension: "markdown") ?? .plainText,
-                    .plainText,
-                ],
-                allowsMultipleSelection: false
-            ) { result in
-                if case .success(let urls) = result, let url = urls.first {
-                    openFile(url)
-                }
-            }
-            .toolbar {
-                ToolbarItem(placement: .automatic) {
-                    Button("Open...") {
-                        showFileImporter = true
-                    }
-                    .keyboardShortcut("o", modifiers: .command)
-                }
-            }
             .navigationTitle(document.title)
-            .onReceive(appDelegate.$fileToOpen.compactMap { $0 }) { url in
-                openFile(url)
-                // Reset AFTER consuming. compactMap above filters the nil
-                // we set here, so onReceive doesn't fire again.
-                appDelegate.fileToOpen = nil
+            .onAppear {
+                DispatchQueue.main.async {
+                    NSApp.keyWindow?.miniwindowTitle = documentURL.lastPathComponent
+                }
             }
     }
 
-    private func openFile(_ url: URL) {
+    private static func load(from url: URL) -> MarkdownDocument {
         let accessing = url.startAccessingSecurityScopedResource()
         defer {
             if accessing { url.stopAccessingSecurityScopedResource() }
         }
-
-        let newDocument: MarkdownDocument
         do {
             let markdown = try String(contentsOf: url, encoding: .utf8)
             let html = renderMarkdown(markdown)
-            newDocument = MarkdownDocument(
+            return MarkdownDocument(
                 html: wrapHTMLPage(body: html),
                 baseURL: url.deletingLastPathComponent(),
                 title: shortenedPath(url.path)
             )
         } catch {
-            newDocument = MarkdownDocument(
+            return MarkdownDocument(
                 html: wrapHTMLPage(body: "<p style='color:red'>Error reading file: \(error.localizedDescription)</p>"),
                 baseURL: nil,
                 title: "Markviewz"
             )
         }
+    }
+}
 
-        // Single atomic state write — SwiftUI rebuilds the view once,
-        // MarkdownWebView.updateNSView loads the content once.
-        document = newDocument
+/// Shown when the app is launched without a file argument.
+struct WelcomeView: View {
+    let onOpen: (URL) -> Void
 
-        // Dock tooltip shows just the filename
-        DispatchQueue.main.async {
-            NSApp.windows.first?.miniwindowTitle = url.lastPathComponent
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Markviewz")
+                .font(.system(size: 48, weight: .light))
+            Text("Open a Markdown file to get started")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Button("Open…") {
+                let panel = NSOpenPanel()
+                panel.allowedContentTypes = [
+                    UTType(filenameExtension: "md") ?? .plainText,
+                    UTType(filenameExtension: "markdown") ?? .plainText,
+                    .plainText,
+                ]
+                panel.allowsMultipleSelection = false
+                if panel.runModal() == .OK, let url = panel.url {
+                    onOpen(url)
+                }
+            }
+            .keyboardShortcut("o", modifiers: .command)
+            Text("or drag a .md file here")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            guard let provider = providers.first else { return false }
+            _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                if let url = url {
+                    DispatchQueue.main.async {
+                        onOpen(url)
+                    }
+                }
+            }
+            return true
         }
     }
 }
@@ -114,7 +113,6 @@ private func shortenedPath(_ path: String) -> String {
     let maxLength = 60
     guard display.count > maxLength else { return display }
 
-    // Keep first component and last two path components, join with ellipsis
     let components = display.components(separatedBy: "/").filter { !$0.isEmpty }
     guard components.count > 3 else { return display }
 
@@ -122,11 +120,3 @@ private func shortenedPath(_ path: String) -> String {
     let suffix = components.suffix(2).joined(separator: "/")
     return prefix + "/\u{2026}/" + suffix
 }
-
-private let welcomeHTML = """
-<div style="text-align: center; margin-top: 100px; opacity: 0.5;">
-    <h1>Markviewz</h1>
-    <p>Open a Markdown file to get started</p>
-    <p style="font-size: 14px;">File → Open (⌘O) or drag a .md file here</p>
-</div>
-"""

--- a/Sources/Markviewz/ContentView.swift
+++ b/Sources/Markviewz/ContentView.swift
@@ -1,6 +1,122 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+// MARK: - Reload notification
+
+extension Notification.Name {
+    /// Posted by AppDelegate when a file that's already open is re-opened
+    /// (e.g. via `markviewz file.md` or `open -a Markviewz file.md`).
+    /// userInfo["url"] carries the canonical URL to reload.
+    static let markviewzReloadFile = Notification.Name("MarkviewzReloadFile")
+}
+
+// MARK: - File watcher
+
+/// Monitors a file for changes using a GCD dispatch source. Publishes a
+/// change counter that SwiftUI views can observe via `.onChange(of:)`.
+///
+/// Handles atomic saves (write-to-temp + rename) by watching for `.delete`,
+/// `.rename`, and `.revoke` events and re-establishing the watch on the new
+/// inode with retries.
+final class FileWatcher: ObservableObject {
+    private let url: URL
+    private var source: DispatchSourceFileSystemObject?
+    private var fileDescriptor: Int32 = -1
+
+    /// Incremented each time a file change is detected.
+    @Published private(set) var changeCount: Int = 0
+
+    init(url: URL) {
+        self.url = url
+        startWatching()
+    }
+
+    deinit { stop() }
+
+    func stop() {
+        source?.cancel() // cancel handler closes fd
+        source = nil
+        fileDescriptor = -1
+    }
+
+    private func startWatching() {
+        let fd = open(url.path, O_EVTONLY)
+        guard fd >= 0 else { return }
+        fileDescriptor = fd
+
+        let src = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .delete, .rename, .revoke],
+            queue: .main
+        )
+        src.setEventHandler { [weak self] in
+            guard let self = self else { return }
+            let flags = src.data
+            if flags.contains(.delete) || flags.contains(.rename) || flags.contains(.revoke) {
+                // Atomic save — file was replaced. Restart watcher on the
+                // new inode, then signal change after successful re-open.
+                self.restartWatching()
+                return
+            }
+            // Normal in-place write.
+            self.changeCount += 1
+        }
+        src.setCancelHandler { close(fd) }
+        self.source = src
+        src.resume()
+    }
+
+    /// Re-establish the watch after an atomic save (delete + rename).
+    /// Retries up to 5 times with increasing delay to handle editors that
+    /// take a moment to move the new file into place.
+    private func restartWatching(attempt: Int = 0) {
+        source?.cancel()
+        source = nil
+        fileDescriptor = -1
+
+        let maxAttempts = 5
+        let delay = 0.1 * Double(attempt + 1) // 100ms, 200ms, ... 500ms
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self = self else { return }
+
+            let fd = open(self.url.path, O_EVTONLY)
+            if fd < 0 {
+                if attempt < maxAttempts - 1 {
+                    self.restartWatching(attempt: attempt + 1)
+                }
+                // After all retries, stop watching. Content stays as-is.
+                return
+            }
+
+            self.fileDescriptor = fd
+            let src = DispatchSource.makeFileSystemObjectSource(
+                fileDescriptor: fd,
+                eventMask: [.write, .delete, .rename, .revoke],
+                queue: .main
+            )
+            src.setEventHandler { [weak self] in
+                guard let self = self else { return }
+                let flags = src.data
+                if flags.contains(.delete) || flags.contains(.rename) || flags.contains(.revoke) {
+                    self.restartWatching()
+                    return
+                }
+                self.changeCount += 1
+            }
+            src.setCancelHandler { close(fd) }
+            self.source = src
+            src.resume()
+
+            // Signal change AFTER successfully re-establishing the watch,
+            // so the view reloads the new file content.
+            self.changeCount += 1
+        }
+    }
+}
+
+// MARK: - Document model
+
 /// Immutable snapshot of what's currently rendered. A single state field
 /// holding the document avoids multiple SwiftUI rebuilds when loading a
 /// new file (previously each of html / baseURL / windowTitle was its
@@ -16,22 +132,36 @@ struct ContentView: View {
     let documentURL: URL
 
     @State private var document: MarkdownDocument
+    @StateObject private var watcher: FileWatcher
 
     init(documentURL: URL) {
         self.documentURL = documentURL
         // Preload synchronously so first render isn't empty.
         _document = State(initialValue: Self.load(from: documentURL))
+        _watcher = StateObject(wrappedValue: FileWatcher(url: documentURL))
     }
 
     var body: some View {
         MarkdownWebView(html: document.html, baseURL: document.baseURL)
             .frame(minWidth: 600, minHeight: 400)
             .navigationTitle(document.title)
+            .onChange(of: watcher.changeCount) {
+                reload()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .markviewzReloadFile)) { notification in
+                if let url = notification.userInfo?["url"] as? URL, url == documentURL {
+                    reload()
+                }
+            }
             .onAppear {
                 DispatchQueue.main.async {
                     NSApp.keyWindow?.miniwindowTitle = documentURL.lastPathComponent
                 }
             }
+    }
+
+    private func reload() {
+        document = Self.load(from: documentURL)
     }
 
     private static func load(from url: URL) -> MarkdownDocument {

--- a/Sources/Markviewz/MarkdownWebView.swift
+++ b/Sources/Markviewz/MarkdownWebView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import WebKit
+import AppKit
 
 /// Shared reference to the current WKWebView for printing.
 class WebViewStore: ObservableObject {
@@ -21,6 +22,7 @@ struct MarkdownWebView: NSViewRepresentable {
 
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.setValue(false, forKey: "drawsBackground")
+        webView.navigationDelegate = context.coordinator
         WebViewStore.shared.webView = webView
         return webView
     }
@@ -45,7 +47,54 @@ struct MarkdownWebView: NSViewRepresentable {
         }
     }
 
-    class Coordinator {
+    /// Intercepts navigation so external links open in the user's default
+    /// browser instead of taking over the Markviewz window. Also opens
+    /// other local markdown files in Markviewz itself (navigation within
+    /// the viewer) by routing through the app delegate.
+    class Coordinator: NSObject, WKNavigationDelegate {
         var lastLoadKey: String?
+
+        func webView(_ webView: WKWebView,
+                     decidePolicyFor navigationAction: WKNavigationAction,
+                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            guard let url = navigationAction.request.url else {
+                decisionHandler(.allow)
+                return
+            }
+
+            // Initial load of the rendered markdown file — allow.
+            // We identify it by the .markviewz-preview.html filename.
+            let isInitialLoad = navigationAction.navigationType == .other
+                && url.isFileURL
+                && url.lastPathComponent == ".markviewz-preview.html"
+            if isInitialLoad {
+                decisionHandler(.allow)
+                return
+            }
+
+            // Local markdown files → route to Markviewz's own open handler
+            // (will reuse-or-spawn window per AppDelegate policy).
+            if url.isFileURL {
+                let ext = url.pathExtension.lowercased()
+                if ext == "md" || ext == "markdown" {
+                    NSWorkspace.shared.open(
+                        [url],
+                        withApplicationAt: Bundle.main.bundleURL,
+                        configuration: NSWorkspace.OpenConfiguration()
+                    ) { _, _ in }
+                    decisionHandler(.cancel)
+                    return
+                }
+                // Non-markdown local file (e.g. image). Open in default app.
+                NSWorkspace.shared.open(url)
+                decisionHandler(.cancel)
+                return
+            }
+
+            // Anything else (http, https, mailto, custom schemes) →
+            // hand off to the default browser/mail client.
+            NSWorkspace.shared.open(url)
+            decisionHandler(.cancel)
+        }
     }
 }

--- a/Sources/Markviewz/MarkviewzApp.swift
+++ b/Sources/Markviewz/MarkviewzApp.swift
@@ -6,16 +6,22 @@ struct MarkviewzApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     var body: some Scene {
-        // Single-window viewer. `Window` (not `WindowGroup`) ensures one
-        // window is reused across file-open events instead of spawning
-        // a new window per invocation of `markviewz <file>`.
-        Window("Markviewz", id: "main") {
-            ContentView()
-                .environmentObject(appDelegate)
+        // Hidden Settings scene — present only to host menu bar commands.
+        // All real windows are managed by AppDelegate via AppKit so we can
+        // implement "reuse window if already showing this file, otherwise
+        // spawn a new one" (SwiftUI's Scene system doesn't compose well
+        // with that dedup-by-value + create-new-for-fresh-value pattern).
+        Settings {
+            EmptyView()
         }
         .commands {
             CommandGroup(replacing: .newItem) { }
             CommandGroup(after: .newItem) {
+                Button("Open…") {
+                    NSApp.sendAction(#selector(AppDelegate.openFileDialog(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("o", modifiers: .command)
+
                 Button("Print…") {
                     printDocument()
                 }
@@ -51,29 +57,145 @@ struct MarkviewzApp: App {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
-    @Published var fileToOpen: URL?
+    /// Windows keyed by canonical file URL. One window per unique file.
+    /// Opening a file that's already visible just brings its window forward.
+    private var windowsByURL: [URL: NSWindow] = [:]
+
+    /// Welcome/no-file window, shown when app launches with no arguments
+    /// and there's no other window visible.
+    private var welcomeWindow: NSWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
 
-        // Handle CLI arguments (when running binary directly)
+        // Close the default Settings window Apple opens automatically.
+        // We don't use it; we manage windows ourselves.
+        DispatchQueue.main.async {
+            NSApp.windows
+                .filter { $0.className.contains("SettingsWindow") || $0.title == "Markviewz Settings" }
+                .forEach { $0.close() }
+        }
+
+        // CLI invocation: `markviewz` binary directly with file arg.
+        // (When invoked via `open -a Markviewz file.md`, file URLs arrive
+        // through application(_:open:) instead.)
         let args = CommandLine.arguments
         if args.count > 1 {
             let path = (args[1] as NSString).standardizingPath
-            fileToOpen = URL(fileURLWithPath: path)
+            openFile(URL(fileURLWithPath: path))
+        } else {
+            // No file given and nothing else is opening — show welcome.
+            DispatchQueue.main.async { [weak self] in
+                if let self = self, self.windowsByURL.isEmpty {
+                    self.showWelcome()
+                }
+            }
         }
     }
 
-    // Handle files opened via `open -a Markviewz file.md` or Finder double-click
+    /// Called by macOS when the app receives file URLs via
+    /// `open -a Markviewz file.md` or Finder double-click.
     func application(_ application: NSApplication, open urls: [URL]) {
-        if let url = urls.first {
-            fileToOpen = url
-        }
-        // Bring window to front when opening a new file
+        urls.forEach { openFile($0) }
         NSApp.activate(ignoringOtherApps: true)
-        if let window = NSApp.windows.first {
-            window.makeKeyAndOrderFront(nil)
+    }
+
+    /// Re-open behavior: when user clicks the dock icon with no windows,
+    /// show welcome rather than doing nothing.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag && windowsByURL.isEmpty {
+            showWelcome()
         }
+        return true
+    }
+
+    /// Don't quit when the last window closes — user may re-open via Dock.
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+
+    // MARK: - File opening
+
+    fileprivate func openFile(_ url: URL) {
+        let canonical = canonicalize(url)
+
+        // Already open — bring forward.
+        if let existing = windowsByURL[canonical] {
+            existing.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        // Not open — spawn a new window.
+        let host = NSHostingController(rootView: ContentView(documentURL: canonical))
+        let window = NSWindow(contentViewController: host)
+        window.title = canonical.lastPathComponent
+        window.setContentSize(NSSize(width: 900, height: 720))
+        window.styleMask.insert(.resizable)
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+
+        windowsByURL[canonical] = window
+
+        // Clean up registry when the user closes the window.
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.windowsByURL.removeValue(forKey: canonical)
+        }
+
+        // Close the welcome window once a real doc is open.
+        welcomeWindow?.close()
+        welcomeWindow = nil
+    }
+
+    // MARK: - Welcome window
+
+    private func showWelcome() {
+        if let existing = welcomeWindow {
+            existing.makeKeyAndOrderFront(nil)
+            return
+        }
+        let host = NSHostingController(rootView: WelcomeView(onOpen: { [weak self] url in
+            self?.openFile(url)
+        }))
+        let window = NSWindow(contentViewController: host)
+        window.title = "Markviewz"
+        window.setContentSize(NSSize(width: 600, height: 400))
+        window.styleMask.insert(.resizable)
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        welcomeWindow = window
+
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.welcomeWindow = nil
+        }
+    }
+
+    // MARK: - Menu command
+
+    @objc func openFileDialog(_ sender: Any?) {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.init(filenameExtension: "md") ?? .plainText,
+                                     .init(filenameExtension: "markdown") ?? .plainText,
+                                     .plainText]
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            openFile(url)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Canonicalize a URL so the same file under different paths (symlinks,
+    /// relative paths, tilde-expansion) resolves to the same registry key.
+    private func canonicalize(_ url: URL) -> URL {
+        url.resolvingSymlinksInPath().standardizedFileURL
     }
 }

--- a/Sources/Markviewz/MarkviewzApp.swift
+++ b/Sources/Markviewz/MarkviewzApp.swift
@@ -6,7 +6,10 @@ struct MarkviewzApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     var body: some Scene {
-        WindowGroup {
+        // Single-window viewer. `Window` (not `WindowGroup`) ensures one
+        // window is reused across file-open events instead of spawning
+        // a new window per invocation of `markviewz <file>`.
+        Window("Markviewz", id: "main") {
             ContentView()
                 .environmentObject(appDelegate)
         }

--- a/Sources/Markviewz/MarkviewzApp.swift
+++ b/Sources/Markviewz/MarkviewzApp.swift
@@ -120,9 +120,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     fileprivate func openFile(_ url: URL) {
         let canonical = canonicalize(url)
 
-        // Already open — bring forward.
+        // Already open — bring forward and reload content.
         if let existing = windowsByURL[canonical] {
             existing.makeKeyAndOrderFront(nil)
+            NotificationCenter.default.post(
+                name: .markviewzReloadFile,
+                object: nil,
+                userInfo: ["url": canonical]
+            )
             return
         }
 


### PR DESCRIPTION
## Summary
- Add `FileWatcher` class using `DispatchSource.makeFileSystemObjectSource` to monitor the open file for write events and auto-reload the rendered markdown content
- Handle atomic saves (write-to-temp + rename) by watching for `.delete`, `.rename`, `.revoke` events and re-establishing the watch with retries (up to 5 attempts with increasing delay)
- Fix `openFile()` to post a reload notification when bringing an already-open window forward, so re-invoking `markviewz file.md` refreshes the content

## Issue
Closes #23

## Test Plan
- Open a .md file in Markviewz, edit it in an external editor (vim, VSCode, etc.), verify the rendered content updates automatically within ~1 second
- Run `markviewz file.md` when the file is already open, verify content refreshes and window comes to front
- Verify atomic saves work (editors that write-to-temp then rename)
- Verify clean build with `swift build` (zero warnings)

## Quality Gates
- [x] Plan reviewed (codex + gemini approved)
- [x] Build passes
- [x] Zero warnings
- [x] Refine pass: clean (extracted shared dispatch source setup)
- [x] Codex code review: APPROVED
- [x] Gemini code review: APPROVED

## Review loop
- Rounds used: 1 / 5
- Deferred concerns: none